### PR TITLE
Fix: Enhanced plugin panel display stability

### DIFF
--- a/css/content-panel.css
+++ b/css/content-panel.css
@@ -1,9 +1,9 @@
 /* Pagetalk 面板样式 */
 #pagetalk-panel-container {
-  position: fixed;
-  top: 0;
-  right: 0;
-  height: 100vh;
+  position: fixed !important;
+  top: 0 !important;
+  right: 0 !important;
+  height: 100vh !important;
   /* width 由 JS 控制并从 localStorage 读取 */
   z-index: 2147483647 !important;
   display: none;
@@ -29,8 +29,8 @@
 }
 
 #pagetalk-panel-iframe {
-  width: 100%;
-  height: 100%;
+  width: 100% !important;
+  height: 100% !important;
   border: none;
 }
 

--- a/js/content.js
+++ b/js/content.js
@@ -174,6 +174,13 @@ function showPanel() {
   if (panel) {
     panel.style.display = 'block';
     panel.style.width = `${panelWidth}px`;
+
+    // Defensively re-apply essential styles
+    panel.style.position = 'fixed';
+    panel.style.top = '0px';
+    panel.style.right = '0px';
+    panel.style.height = '100vh';
+
     document.body.classList.add('pagetalk-panel-open');
 
     const currentUrl = window.location.href;


### PR DESCRIPTION
This addresses the issue you reported where the plugin panel might appear in the bottom left corner or be too small on certain web pages.

The main changes include:
1. In `css/content-panel.css`, I added `!important` declarations to the `position`, `top`, `right`, `height` styles for `#pagetalk-panel-container` and the `width`, `height` styles for `#pagetalk-panel-iframe`. This increases their priority to prevent them from being overridden by the host page's CSS.
2. In the `showPanel` function in `js/content.js`, I added code to directly set the `position`, `top`, `right`, and `height` styles of the panel container via JavaScript. This acts as an additional safeguard to ensure the panel is positioned and sized correctly, even if CSS rules don't fully apply for some reason.
3. I reviewed the logic regarding the panel's minimum width in `js/content.js` and confirmed it's working as expected.

These changes are intended to improve the robustness of the plugin panel's display across various website environments.