### PR TITLE
feat: Add custom API endpoint setting for proxy/intermediary support

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -104,7 +104,10 @@ git clone https://github.com/jeanchristophe13v/PageTalk.git
 - **设置标签页:** (包含通用、助手、模型子标签页)
     *   **通用:** 切换语言/主题，导出聊天记录。
     *   **助手:** 管理助手，导入/导出配置。
-    *   **模型:** 设置 API 密钥，选择默认模型。
+    *   **模型:** 设置 API 密钥，选择默认模型，以及可选的 **自定义 API 端点**。
+        *   **自定义 API 端点 (Custom API Endpoint):** 此设置允许您将 Google Gemini API 请求通过中间服务（例如 OneAPI）进行路由。这对于那些所在地区直接访问 Google API 受限的用户，或者希望利用这类中间服务提供的 API 密钥轮换、缓存或高级日志记录等功能的用户来说非常有用。
+        *   **示例:** `https://your-oneapi-instance.com/v1beta` (请确保路径与您的中间服务为 Gemini API 所期望的路径一致)。
+        *   **默认值:** 如果留空，插件将使用默认端点 `https://generativelanguage.googleapis.com/v1beta`。
 
 ## 💗感谢DartNode的支持 ~
 [![Powered by DartNode](https://dartnode.com/branding/DN-Open-Source-sm.png)](https://dartnode.com "Powered by DartNode - Free VPS for Open Source")

--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ git clone https://github.com/jeanchristophe13v/PageTalk.git
 - **Settings Tab:** (Contains General, Agents, Model sub-tabs)
     *   **General:** Switch Language/Theme, Export Chat History.
     *   **Agents:** Manage agents, Import/Export configurations.
-    *   **Model:** Set API Key, select default model.
+    *   **Model:** Set API Key, select default model, and optionally configure a **Custom API Endpoint**.
+        *   **Custom API Endpoint:** This setting allows you to route Google Gemini API requests through an intermediary service (e.g., OneAPI). This can be useful for users in regions with restricted access to Google's direct APIs or for those who wish to leverage features like API key rotation, caching, or advanced logging provided by such services.
+        *   **Example:** `https://my-oneapi-instance.com/v1beta` (ensure the path matches what your intermediary service expects for Gemini).
+        *   **Default:** If left empty, the extension uses `https://generativelanguage.googleapis.com/v1beta`.
  
 ## 💗 Thanks support from DartNode 
 

--- a/html/sidepanel.html
+++ b/html/sidepanel.html
@@ -224,6 +224,11 @@
                                 <p class="hint"><span data-i18n="apiKeyHint"></span>  <a href="https://aistudio.google.com/" target="_blank" rel="noopener">Google AI Studio</a></p>
                             </div>
                             <div class="setting-group">
+                                <label for="custom-api-endpoint-input">Custom API Endpoint:</label>
+                                <input type="text" id="custom-api-endpoint-input" placeholder="Enter Custom API Endpoint">
+                                <p class="hint">Default: https://generativelanguage.googleapis.com/v1beta</p>
+                            </div>
+                            <div class="setting-group">
                                 <label for="model-selection">模型：</label>
                                 <select id="model-selection">
                                     <option value="gemini-2.0-flash">gemini-2.0-flash</option>

--- a/js/api.js
+++ b/js/api.js
@@ -8,9 +8,10 @@ const API_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
  * Internal helper to test API key and model validity.
  * @param {string} apiKey - The API key to test.
  * @param {string} model - The model to test against. Can be a "logical" model name.
+ * @param {string} [customApiEndpoint] - Optional custom API endpoint.
  * @returns {Promise<{success: boolean, message: string}>} - Object indicating success and a message.
  */
-async function _testAndVerifyApiKey(apiKey, model) {
+async function _testAndVerifyApiKey(apiKey, model, customApiEndpoint) {
     try {
         let apiTestModel = model;
         // Map logical model names to actual API model names for testing if necessary
@@ -18,10 +19,12 @@ async function _testAndVerifyApiKey(apiKey, model) {
             apiTestModel = 'gemini-2.5-flash-preview-05-20';
         }
 
+        const baseUrlToUse = (customApiEndpoint && customApiEndpoint.trim() !== '') ? customApiEndpoint.trim() : API_BASE_URL;
+
         const requestBody = {
             contents: [{ role: 'user', parts: [{ text: 'test' }] }] // Simple test payload
         };
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${apiTestModel}:generateContent?key=${apiKey}`, {
+        const response = await fetch(`${baseUrlToUse}/models/${apiTestModel}:generateContent?key=${apiKey}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(requestBody)
@@ -272,7 +275,8 @@ async function callGeminiAPIInternal(userMessage, images = [], videos = [], thin
             return;
         }
 
-        const endpoint = `${API_BASE_URL}/models/${apiModelName}:streamGenerateContent?key=${stateRef.apiKey}&alt=sse`; // Use actual apiModelName
+        const baseUrlToUse = (stateRef.customApiEndpoint && stateRef.customApiEndpoint.trim() !== '') ? stateRef.customApiEndpoint.trim() : API_BASE_URL;
+        const endpoint = `${baseUrlToUse}/models/${apiModelName}:streamGenerateContent?key=${stateRef.apiKey}&alt=sse`; // Use actual apiModelName
 
         const response = await fetch(endpoint, {
             method: 'POST',


### PR DESCRIPTION
This commit introduces a new setting that allows you to specify a custom API base URL.

The key changes include:
- Added an input field in the settings panel (Model section) for the "Custom API Endpoint".
- The extension now saves this custom endpoint to storage.
- API calls in `js/api.js` (both for testing the key and making content generation requests) will use this custom endpoint if provided. If not, they default to 'https://generativelanguage.googleapis.com/v1beta'.
- Updated `README.md` and `README-zh.md` to explain this new feature, highlighting its utility for you if you need to route API calls through a proxy or an intermediary service like OneAPI.

This feature addresses the issue where you, in restricted regions, cannot directly access Google's APIs by enabling you to use a self-hosted or third-party intermediary that can handle proxying. It also allows you to leverage other features of such intermediaries, like API key rotation.