### PR TITLE
feat: Implement API request proxy functionality through a background …

### DIFF
--- a/html/sidepanel.html
+++ b/html/sidepanel.html
@@ -149,6 +149,12 @@
                                 </select>
                             </div>
                         </div>
+                        <div class="setting-group">
+                            <label for="proxy-address">代理地址 (Proxy Address):</label>
+                            <div class="export-controls"> <!-- Re-using existing class for layout consistency -->
+                                <input type="text" id="proxy-address" placeholder="例如：http://localhost:8080">
+                            </div>
+                        </div>
                         <div class="setting-group export-setting">
                             <label for="export-format">导出聊天记录：</label>
                             <div class="export-controls">

--- a/js/main.js
+++ b/js/main.js
@@ -78,7 +78,8 @@ const state = {
     selectedContextTabs: [], // 新增：存储用户选择的用于上下文的标签页
     availableTabsForSelection: [], // 新增：存储查询到的供用户选择的标签页
     isTabSelectionPopupOpen: false, // 新增：跟踪标签页选择弹窗的状态
-    locallyIgnoredTabs: {}, // 新增: 跟踪用户从特定消息上下文中移除的标签页 { messageId: [tabId1, tabId2] }
+        locallyIgnoredTabs: {}, // 新增: 跟踪用户从特定消息上下文中移除的标签页 { messageId: [tabId1, tabId2] },
+        proxyAddress: '', // Ensure this line is present or added
 };
 
 // Default settings (used by agent module)
@@ -159,6 +160,7 @@ const elements = {
     // Footer Status Bar
     contextStatus: document.getElementById('context-status'),
     connectionIndicator: document.getElementById('connection-indicator'),
+    proxyAddress: document.getElementById('proxy-address'), // Ensure this line is present or added
 };
 
 // --- Translation ---

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,9 @@
     "activeTab",
     "storage",
     "scripting",
-    "contextMenus"
+    "contextMenus",
+    "alarms",
+    "<all_urls>"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
…script

I've added proxy server support to PageTalk, allowing you to configure a proxy address in the general settings and send Google API requests through it.

Key changes include:

1.  **Settings Interface Update (`html/sidepanel.html`, `js/settings.js`, `js/main.js`)**:
    *   I added a "Proxy Address" input field in the "General" settings.
    *   I updated the settings loading and saving logic to include the proxy address.
    *   I ensured the initialization and mapping of the relevant state (`state.proxyAddress`) and DOM elements (`elements.proxyAddress`).

2.  **Background Proxy Request Handling (`js/background.js`, `manifest.json`)**:
    *   I created the `js/background.js` service.
    *   In `manifest.json`, I added `"alarms"` and `"<all_urls>"` permissions and declared the background script.
    *   The background script listens for `proxyFetch` messages from `js/api.js`.
    *   If a proxy is configured, I modify the target URL (format: `PROXY_URL/TARGET_URL`) and execute a `fetch` request.
    *   The `fetch` result is returned to `js/api.js` via a message callback.

3.  **API Call Logic Update (`js/api.js`)**:
    *   I modified the `_testAndVerifyApiKey` and `callGeminiAPIInternal` functions.
    *   If a proxy is configured, I send the request parameters to `background.js` via `chrome.runtime.sendMessage`.
    *   If no proxy is configured, I use the original direct `fetch` call.
    *   I removed the previous attempt to modify URLs directly in `js/api.js` for proxying.

**Important Limitations**:
*   **SSE Streaming Not Supported**: The current proxy implementation via the background script does not support Server-Sent Events (SSE) streaming. When using a proxy, responses from the Gemini API will be fully buffered and then displayed at once, rather than streamed progressively. Direct (non-proxied) calls are unaffected and continue to support SSE.
*   **Proxy Server Compatibility**: The success of the proxy depends on how your provided proxy server handles requests formatted as `PROXY_URL/TARGET_URL`. Not all proxy servers support this pattern.
*   **Permissions**: I've used the `"<all_urls>"` permission to allow connection to any proxy server you specify.

I recommend conducting real-world testing with various proxy server configurations after deployment.