### PR TITLE
fix textarea color overriding ua stylesheet

### DIFF
--- a/css/_chat.css
+++ b/css/_chat.css
@@ -927,6 +927,8 @@ body.dark-mode .bot-message:hover {
     line-height: 1.5;
     outline: none;
     overflow-y: auto;
+    color: var(--text-color);
+    caret-color: var(--text-color);
 }
 
 .chat-input textarea::placeholder {


### PR DESCRIPTION
## Summary
- Explicitly set textarea `color` and `caret-color` in the chat input to prevent UA `fieldtext` from taking precedence
- Keep theme variables aligned so text stays correct in light/dark modes

## Reason
- In the Arc browser the chat input text occasionally inherited the UA `fieldtext` color, leading to theme-inconsistent text; explicitly setting the color avoids the override

## Testing
- Manual: open the side panel, toggle light/dark, confirm textarea text and caret follow the theme colors